### PR TITLE
deterministic pod names

### DIFF
--- a/cmd/m3_generate/main/main.go
+++ b/cmd/m3_generate/main/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	_ "net/http/pprof" // pprof: for debug listen server if configured
@@ -21,7 +22,6 @@ import (
 	"github.com/m3db/m3/src/query/models"
 	"github.com/m3db/m3/src/x/ident"
 	"github.com/m3db/m3/src/x/instrument"
-	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
 )
 
@@ -54,6 +54,11 @@ func main() {
 
 	start := time.Now().Truncate(blockSize).Add(-1 * blockSize)
 	timeNowFn := func() time.Time { return start }
+
+	podNameRng := rand.New(rand.NewSource(0)) // deterministic
+	podNameFn := func() string {
+		return fmt.Sprintf("%x-%x", podNameRng.Uint64(), podNameRng.Uint64())
+	}
 
 	gen := generator.NewHostsSimulator(10000, start,
 		generator.HostsSimulatorOptions{TimeNowFn: timeNowFn})
@@ -128,7 +133,7 @@ TopLoop:
 				}
 				fields = append(fields, doc.Field{
 					Name:  podTag,
-					Value: []byte(uuid.NewV4().String()),
+					Value: []byte(podNameFn()),
 				})
 
 				tags = tags.Reset()

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -325,6 +325,7 @@ golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=


### PR DESCRIPTION
Hi there,

I'm not sure you're really looking for contributions here, but in case so...

In your FOSDEM talk, you noticed that the matched time-series numbers were different between the prom and m3 runs.  Turns out it's different on every run, because the generate step uses real randomized pod names.

This patch changes the pod names to come from a 0-seeded non-crypto RNG, so that for a given cardinality, `prom_benchindex` and `m3_benchindex` always find the same number of postings (for the default cardinality of 5M, that happens to be `1284`).

Cheers.